### PR TITLE
Add explicit platform to lcas-jammy docker compose file

### DIFF
--- a/kasm-lcas-jammy.docker-compose.yaml
+++ b/kasm-lcas-jammy.docker-compose.yaml
@@ -14,6 +14,7 @@ networks:
 services:
   kasm-desktop:
     container_name: "kasm_lcas_jammy_${USER:-default}"
+    platform: linux/amd64
     build: 
       context: .
       dockerfile: dockerfile-kasm-lcas-jammy-humble


### PR DESCRIPTION
On m1 mac, docker tries to start the docker image, which was originally built for amd64 in native mode and complains that the cpu architecture does not match. Add the platform option allow docker to start the container in emulation mode, which enables the whole thing to run without problem on m1 mac.